### PR TITLE
[Pruning] use cbind2 for dgCMatrix. 

### DIFF
--- a/R/apps.R
+++ b/R/apps.R
@@ -2829,7 +2829,7 @@ fitcn = function (gw, cn.field = "cn", trim = TRUE, weight = NULL, obs.mat = NUL
         )
         A = rbind(
             ## cbind(K, Zero[rep(1, nrow(K)), (w + 1:w)]),
-            cbind(Reduce(`diagc`, lapply(seq_len(nblock), function(i) K)), Zero[rep(1, nrow(K) * nblock), (w + 1:w)]),
+            cbind2(Reduce(`diagc`, lapply(seq_len(nblock), function(i) K)), Zero[rep(1, nrow(K) * nblock), (w + 1:w)]),
             Amub,
             Amlb
         )

--- a/R/gGnome.R
+++ b/R/gGnome.R
@@ -7928,7 +7928,7 @@ gWalk = R6::R6Class("gWalk", ## GWALKS
                               ## lower bound > 0 if indicator is positive
                               Amlb = cbind(diag(rep(1, w)), diag(rep(-0.1, w)))
 
-                              A = rbind(cbind(K, Zero[rep(1, nrow(K)), (w+1:w)]), Amub, Amlb)
+                              A = rbind(cbind2(K, Zero[rep(1, nrow(K)), (w+1:w)]), Amub, Amlb)
                               return(A)
                           }
 


### PR DESCRIPTION
For some reason sometimes we need to excplcitly use cbind2 to avoid R trying to apply the data.frame cbind and attempt to coerce the dgCMatrix to a data.frame