### PR TITLE
matrix coercion to vector when nrow = 2 bug fix

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -142,7 +142,7 @@ convex.basis = function(A,
                     H = combs %*% K_last;
 
                                         # remove duplicated rows in H (with respect to sparsity)
-                    H = H[!duplicated(as.matrix(H)>ZERO), ];
+                    H = H[!duplicated(as.matrix(H)>ZERO), , drop = F];
 
                                         # remove rows in H that have subsets in H (with respect to sparsity) ..
                     if ((as.numeric(nrow(H))*as.numeric(nrow(H)))>maxchunks){


### PR DESCRIPTION
**Description:**

- bug fix for TIC calls in complex events calling

**Changes:**

- drop = F



**Related Issues:**

- error in utils.R line 148 at the `tic()` events call
