### PR TITLE
Modified blank Makevars to not use -m64 for aarch64 machines

### DIFF
--- a/srcs/src.blank/Makevars
+++ b/srcs/src.blank/Makevars
@@ -1,3 +1,11 @@
-PKG_CFLAGS=-m64 -fPIC -fno-strict-aliasing
-PKG_CPPFLAGS=-I${CPLEX_DIR}/cplex/include
-PKG_LIBS=-lm -lpthread
+ARCH := $(shell uname -m)
+
+ifeq ($(strip $(ARCH)),aarch64)  # Ensure no whitespace or newline issues
+    PKG_CFLAGS=-fPIC -fno-strict-aliasing
+    PKG_LIBS=-lm -lpthread
+else
+    PKG_CFLAGS=-m64 -fPIC -fno-strict-aliasing
+    PKG_LIBS=-lm -lpthread
+endif
+
+PKG_CPPFLAGS=-I$(CPLEX_DIR)/cplex/include


### PR DESCRIPTION
**Description:**

- Installing gGnome in a container on an apple silicon machine would throw -m64 errors during compilation
- Modification to the src.blank Makevars to detect `aarch64` arch allows avoiding -m64 for this arch

**Changes:**

- Added an ifelse to the Makevars to avoid setting -m64 if uname -m returns `aarch64`

**Impact:**

- -m64 is no longer set for aarch64 machines

**Related Issues:**

- Resolves #136 and the issue I was about to create about this
